### PR TITLE
レスポンスが文字列になる問題を修正

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,23 +1,30 @@
 import type { PostType } from "../types/post.js"
 import type { UserInfoType } from "../types/user.js"
-import { Axios } from "axios"
+import axios, { type Axios } from "axios"
 
-export class Client extends Axios {
+export class Client {
+  private apiKey: string | undefined
+  private client: Axios
+
   constructor(apiKey?: string) {
-    super({ baseURL: "https://karotter.com", headers: { "X-API-Key": apiKey } })
+    this.apiKey = apiKey
+    this.client = axios.create({
+      baseURL: "https://karotter.com",
+      headers: { "X-API-Key": this.apiKey },
+    })
   }
 
   async getUser(userName: string) {
-    const data = await this.get<UserInfoType>(`/api/users/${userName}`).then(
-      (res) => res.data,
-    )
+    const data = await this.client
+      .get<UserInfoType>(`/api/users/${userName}`)
+      .then((res) => res.data)
     return data
   }
 
   async getPost(id: number) {
-    const data = await this.get<PostType>(`/api/posts/${id}`).then(
-      (res) => res.data,
-    )
+    const data = await this.client
+      .get<PostType>(`/api/posts/${id}`)
+      .then((res) => res.data)
     return data
   }
 }


### PR DESCRIPTION
Resolves #3

`Client`が`Axios`を継承しないように変更し、`private client`で内部的に`Axios`を持たせるように変更し、
コンストラクタで正しい方法で`Axios`を初期化するようにし、問題を解決しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * HTTP クライアント実装の内部構造を改善し、保守性と拡張性が向上しました。API の動作に変わりはありませんが、よりモダンな設計パターンを採用しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->