### PR TITLE
package.jsonの無効なtypesフィールドを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,5 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Cheesecake2960/karotter-js.git"
-  },
-  "types": "dist/index.d.ts"
+  }
 }


### PR DESCRIPTION
Resolves #10

# 説明
#2 で誤って追加された無効な型定義ファイルを参照していた`types`フィールドを削除しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージ設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->