### PR TITLE
ThreadTypeのreactionSummaryをReactionSummaryTypeに変更

### DIFF
--- a/types/board.d.ts
+++ b/types/board.d.ts
@@ -1,3 +1,4 @@
+import type { ReactionSummaryType } from "./reaction.js"
 import type { UserType } from "./user.js"
 
 export type BoardType = {
@@ -67,7 +68,7 @@ export type ThreadType = {
   lastReplyAt: string
 
   /** 投稿に対して行われたリアクション。 */
-  reactionSummary: { emoji: string; count: number; reacted: boolean }[]
+  reactionSummary: ReactionSummaryType[]
 
   /** 返信の数。 */
   replyCount: number


### PR DESCRIPTION
Resolves #13

# 変更点
`ThreadType`の`reactionSummary`の型を`ReactionSummaryType[]`に変更し、
共通化しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部型定義の最適化を実施しました。ユーザーに見える機能的な変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->